### PR TITLE
use only a fixed sigma instead of the velocity error of the measurements

### DIFF
--- a/dvl_seapilot.orogen
+++ b/dvl_seapilot.orogen
@@ -16,10 +16,8 @@ task_context "Task" do
     # the time interval the device will output the averaged profile/bottom track samples
     property("ensemble_interval", "double", 0.5)
     
-    # Standard deviation override
-    property('sigma_override', 'double', 0.0).
-        doc("If sigma_override is a valid value greater than zero, it will").
-        doc("be used to override the covariance of the velocity measurements.")
+    # Standard deviation of the velocity messurements
+    property('sigma', 'double', 0.01)
         
     #Default variance of avg ground-distance readings
     property("variance_ground_distance", "double", 0.1)


### PR DESCRIPTION
The background is that the velocity error of each DVL measurement is only the difference
of the velocity that was measured on each beam. It could be a really small value,
which would lead to an overconfident velocity measurement.
