### PR TITLE
fix timestamp estimator setup

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -33,7 +33,7 @@ void Task::processIO()
     else
         global_seq += seq - last_seq;
     last_seq = seq;
-    base::Time time = timestamp_estimator->update(base_time, global_seq);
+    base::Time time = timestamp_estimator.update(base_time, global_seq);
 
     // Update the timestamp on each of the fields, and write it on our outputs
     driver->status.time = time;
@@ -121,7 +121,7 @@ void Task::processIO()
     }
 
     // write timestamp estimator status
-     _timestamp_estimator_status.write(timestamp_estimator->getStatus());
+     _timestamp_estimator_status.write(timestamp_estimator.getStatus());
 }
 
 
@@ -141,8 +141,6 @@ bool Task::configureHook()
 
     setDriver(driver.get());
 
-    timestamp_estimator.reset(new aggregator::TimestampEstimator(base::Time::fromSeconds(100),base::Time::fromSeconds(0.1)));
-
     if (! TaskBase::configureHook())
         return false;
     return true;
@@ -153,7 +151,10 @@ bool Task::startHook()
         return false;
 
     driver->startAcquisition();
-    timestamp_estimator->reset();
+    timestamp_estimator.reset(
+            base::Time::fromSeconds(100),
+            base::Time::fromSeconds(_ensemble_interval.value()),
+            INT_MAX);
     last_seq = -1;
 
     return true;

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -30,7 +30,7 @@ namespace dvl_seapilot {
         
     protected:
         boost::shared_ptr<dvl_seapilot::Driver> driver;
-        boost::shared_ptr<aggregator::TimestampEstimator> timestamp_estimator;
+        aggregator::TimestampEstimator timestamp_estimator;
         
         // The sequence number without wraparounds
         uint64_t global_seq;


### PR DESCRIPTION
The packet loss was set to the default of 2, and the initial period
was completely wrong, which led to timestamping to be utterly broken
(as the timestamp estimator status stream would clearly show)

Since I don't know the actual period, I removed the initial period
completely and let the estimator estimate it, and set up the loss
threshold to INT_MAX since we use sequence numbers.

Also modified to remove the nonsensical use of a shared_ptr

This has been tested on a real device, and does fix the issue there.