### PR TITLE
disable the timestamp estimator

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -33,7 +33,8 @@ void Task::processIO()
     else
         global_seq += seq - last_seq;
     last_seq = seq;
-    base::Time time = timestamp_estimator.update(base_time, global_seq);
+    timestamp_estimator.update(base_time, global_seq);
+    base::Time time = base_time;
 
     // Update the timestamp on each of the fields, and write it on our outputs
     driver->status.time = time;


### PR DESCRIPTION
The DVL is essentially a latency-free sensor, and on our system at
least, has very little jitter on top.

However, it's not fully periodic when the bottom lock gets lost. This
(rightly) confuses the timestamp estimator, which drifts and causes
havoc even when the samples are received again.

Given that it seems that the estimator itself has very little benefit
w.r.t the quality of the timestamping, disable it.